### PR TITLE
Changing output timestamp

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -286,7 +286,7 @@ namespace RobotLocalization
         }
       }
 
-      message.header.stamp = ros::Time::now();
+      message.header.stamp = ros::Time(filter_.getLastMeasurementTime());
       message.header.frame_id = worldFrameId_;
       message.child_frame_id = baseLinkFrameId_;
     }


### PR DESCRIPTION
Pretty simple change. We were stamping the r_l output with `ros::Time::now()`, but we should be stamping the output with the time stamp of the last measurement we processed. Note that this places some onus on the user to make sure their data isn't really out of sync, but that isn't (and shouldn't be) the filter's responsibility.

FYI @bradleypowers @davelkan @kayak0806 @tappan-at-git 