### PR TITLE
RST-47 initial state

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -813,17 +813,20 @@ namespace RobotLocalization
     nhLocal_.param("dynamic_process_noise_covariance", dynamicProcessNoiseCovariance, false);
     filter_.setUseDynamicProcessNoiseCovariance(dynamicProcessNoiseCovariance);
 
-    std::vector<double> initial_state(STATE_SIZE, 0.0);
-    if(nhLocal_.getParam("initial_state", initial_state))
+    std::vector<double> initialState(STATE_SIZE, 0.0);
+    if(nhLocal_.getParam("initial_state", initialState))
     {
-      if(initial_state.size() != STATE_SIZE)
+      if(initialState.size() != STATE_SIZE)
       {
-        ROS_ERROR_STREAM("Initial state must be of size " << STATE_SIZE << ". Provided config was of "
-          "size " << initial_state.size() << ". The initial state will be ignored.");
+        ROS_ERROR_STREAM("Initial state must be of size " << STATE_SIZE << ". Provided config was of size " <<
+          initialState.size() << ". The initial state will be ignored.");
+      }
+      else
+      {
+        Eigen::Map<Eigen::VectorXd> eigenState(initialState.data(), initialState.size());
+        filter_.setState(eigenState);
       }
     }
-    Eigen::Map<Eigen::VectorXd> eigen_state(initial_state.data(), initial_state.size());
-    filter_.setState(eigen_state);
 
     // Debugging writes to file
     RF_DEBUG("tf_prefix is " << tfPrefix <<
@@ -845,7 +848,7 @@ namespace RobotLocalization
              "\nacceleration_gains are " << accelerationLimits <<
              "\ndeceleration_limits are " << decelerationLimits <<
              "\ndeceleration_gains are " << decelerationLimits <<
-             "\ninitial state is " << eigen_state <<
+             "\ninitial state is " << filter_.getState() <<
              "\ndynamic_process_noise_covariance is " << (dynamicProcessNoiseCovariance ? "true" : "false") <<
              "\nprint_diagnostics is " << (printDiagnostics_ ? "true" : "false") << "\n");
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -814,10 +814,6 @@ namespace RobotLocalization
     filter_.setUseDynamicProcessNoiseCovariance(dynamicProcessNoiseCovariance);
 
     std::vector<double> initial_state(STATE_SIZE, 0.0);
-    if (nhLocal_.hasParam("initial_state"))
-    {
-      std::cerr << "TAM: it's here!\n\n\n\n";
-    }
     if(nhLocal_.getParam("initial_state", initial_state))
     {
       if(initial_state.size() != STATE_SIZE)

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -813,6 +813,22 @@ namespace RobotLocalization
     nhLocal_.param("dynamic_process_noise_covariance", dynamicProcessNoiseCovariance, false);
     filter_.setUseDynamicProcessNoiseCovariance(dynamicProcessNoiseCovariance);
 
+    std::vector<double> initial_state(STATE_SIZE, 0.0);
+    if (nhLocal_.hasParam("initial_state"))
+    {
+      std::cerr << "TAM: it's here!\n\n\n\n";
+    }
+    if(nhLocal_.getParam("initial_state", initial_state))
+    {
+      if(initial_state.size() != STATE_SIZE)
+      {
+        ROS_ERROR_STREAM("Initial state must be of size " << STATE_SIZE << ". Provided config was of "
+          "size " << initial_state.size() << ". The initial state will be ignored.");
+      }
+    }
+    Eigen::Map<Eigen::VectorXd> eigen_state(initial_state.data(), initial_state.size());
+    filter_.setState(eigen_state);
+
     // Debugging writes to file
     RF_DEBUG("tf_prefix is " << tfPrefix <<
              "\nmap_frame is " << mapFrameId_ <<
@@ -833,6 +849,7 @@ namespace RobotLocalization
              "\nacceleration_gains are " << accelerationLimits <<
              "\ndeceleration_limits are " << decelerationLimits <<
              "\ndeceleration_gains are " << decelerationLimits <<
+             "\ninitial state is " << eigen_state <<
              "\ndynamic_process_noise_covariance is " << (dynamicProcessNoiseCovariance ? "true" : "false") <<
              "\nprint_diagnostics is " << (printDiagnostics_ ? "true" : "false") << "\n");
 


### PR DESCRIPTION
This PR adds a parameter to robot_localization that enables us to specify the initial state. This is especially useful in sim.

@locusrobotics/robot-software-team 