### PR TITLE
RST-650 Fixing critical bug with dynamic process noise covariance

### DIFF
--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -313,6 +313,7 @@ namespace RobotLocalization
   void FilterBase::setProcessNoiseCovariance(const Eigen::MatrixXd &processNoiseCovariance)
   {
     processNoiseCovariance_ = processNoiseCovariance;
+    dynamicProcessNoiseCovariance_ = processNoiseCovariance_;
   }
 
   void FilterBase::setSensorTimeout(const double sensorTimeout)


### PR DESCRIPTION
Stupid bug. Without this change, it was ignoring the process noise covariance entries for velocity.