### PR TITLE
Silencing unnecessary errors and warnings

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1906,12 +1906,17 @@ namespace RobotLocalization
       }
 
       ros::Duration loop_elapsed_time = ros::Time::now() - loop_end_time;
-      ros::Duration sleep_time = loop_cycle_time - loop_elapsed_time;
 
-      if (!sleep_time.sleep())
+      if (loop_elapsed_time > loop_cycle_time)
       {
-        ROS_WARN_STREAM("Failed to meet update rate! Took " << std::setprecision(20) << loop_elapsed_time.toSec() <<
-          " seconds. Try decreasing the rate, limiting sensor output frequency, or limiting the number of sensors.");
+        ROS_WARN_STREAM_DELAYED_THROTTLE(1.0, "Failed to meet update rate! Took " << std::setprecision(20) <<
+          loop_elapsed_time.toSec() << " seconds. Try decreasing the rate, limiting sensor output frequency, or "
+          "limiting the number of sensors.");
+      }
+      else
+      {
+        ros::Duration sleep_time = loop_cycle_time - loop_elapsed_time;
+        sleep_time.sleep();
       }
 
       loop_end_time = ros::Time::now();

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -498,8 +498,9 @@ namespace RobotLocalization
         if (!revertTo(firstMeasurement->time_ - 1e-9))
         {
           RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurement->time_ << "\n");
-          ROS_WARN_STREAM_THROTTLE(10.0, "Received old measurement for topic " << firstMeasurement->topicName_ <<
-                                   ", but history interval is insufficiently sized to revert state and measurement queue.");
+          ROS_WARN_STREAM_DELAYED_THROTTLE(historyLength_, "Received old measurement for topic " <<
+            firstMeasurement->topicName_ << ", but history interval is insufficiently sized to revert state and "
+            "measurement queue.");
           restoredMeasurementCount = 0;
         }
 
@@ -1775,13 +1776,15 @@ namespace RobotLocalization
       accelPub = nh_.advertise<geometry_msgs::AccelWithCovarianceStamped>("accel/filtered", 20);
     }
 
-    ros::Rate loop_rate(frequency_);
+    const ros::Duration loop_cycle_time(1.0 / frequency_);
+    ros::Time loop_end_time = ros::Time::now();
 
     while (ros::ok())
     {
+      ros::spinOnce();
+
       // The spin will call all the available callbacks and enqueue
       // their received measurements
-      ros::spinOnce();
       curTime = ros::Time::now();
 
       // Now we'll integrate any measurements we've received
@@ -1824,7 +1827,8 @@ namespace RobotLocalization
                      odomBaseLinkTrans,
                      true))
               {
-                ROS_ERROR_STREAM("Unable to retrieve " << odomFrameId_ << "->" << baseLinkFrameId_ << " transform. Skipping iteration...");
+                ROS_ERROR_STREAM_DELAYED_THROTTLE(1.0, "Unable to retrieve " << odomFrameId_ << "->" <<
+                  baseLinkFrameId_ << " transform. Skipping iteration...");
                 continue;
               }
 
@@ -1901,11 +1905,16 @@ namespace RobotLocalization
         clearExpiredHistory(filter_.getLastMeasurementTime() - historyLength_);
       }
 
-      if (!loop_rate.sleep())
+      ros::Duration loop_elapsed_time = ros::Time::now() - loop_end_time;
+      ros::Duration sleep_time = loop_cycle_time - loop_elapsed_time;
+
+      if (!sleep_time.sleep())
       {
-        ROS_WARN_STREAM("Failed to meet update rate! Try decreasing the rate, limiting "
-                        "sensor output frequency, or limiting the number of sensors.");
+        ROS_WARN_STREAM("Failed to meet update rate! Took " << std::setprecision(20) << loop_elapsed_time.toSec() <<
+          " seconds. Try decreasing the rate, limiting sensor output frequency, or limiting the number of sensors.");
       }
+
+      loop_end_time = ros::Time::now();
     }
   }
 


### PR DESCRIPTION
Note that this is a PR into the state history branch.

r_l talks too much. Specifically,

- It warns us at the start of execution about insufficient history length, before we've even had time to generate the history
- It yells at us rapidly about missing transforms during startup
- Most irritatingly, it warns us constantly about missing the update rate

The last warning is especially annoying because r_l is barely touching the CPU. It can plow through an update of 10 measurements in a single update iteration and only eat 0.0002 seconds. The warning is printed because the ROS loop rate `sleep` yells at us, but after investigating, it's yelling at us needlessly. I have implemented the logic that I wanted from the loop rate timer, and it is now silenced.

FYI @locusrobotics/robot-software-team 