### PR TITLE
RST-816 Fixing issue with invalidated pointer

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -495,11 +495,13 @@ namespace RobotLocalization
           " seconds in the past. Reverting filter state and measurement queue...");
 
         int originalCount = static_cast<int>(measurementQueue_.size());
-        if (!revertTo(firstMeasurement->time_ - 1e-9))
+        const double firstMeasurementTime =  firstMeasurement->time_;
+        const std::string firstMeasurementTopic =  firstMeasurement->topicName_;
+        if (!revertTo(firstMeasurement->time_ - 1e-9))  // revertTo may invalidate firstMeasurement
         {
-          RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurement->time_ << "\n");
+          RF_DEBUG("ERROR: history interval is too small to revert to time " << firstMeasurementTime << "\n");
           ROS_WARN_STREAM_DELAYED_THROTTLE(historyLength_, "Received old measurement for topic " <<
-            firstMeasurement->topicName_ << ", but history interval is insufficiently sized to revert state and "
+              firstMeasurementTopic << ", but history interval is insufficiently sized to revert state and "
             "measurement queue.");
           restoredMeasurementCount = 0;
         }


### PR DESCRIPTION
Addresses [RST-816](https://locusrobotics.atlassian.net/browse/RST-816). I was getting a const reference to the `top` of the priority queue, whose underlying structure is a `std::vector`. When `revertTo` is called, it will possibly (likely, really) resize the underlying vector, because it needs to add a slew of historical measurements to the queue. Adding elements to vectors invalidates all iterators and references/pointers, so `firstMeasurement` was often pointing somewhere completely invalid. We've been getting lucky, in that it's been printing most of the time with no issues (it's probably the case that the vector isn't getting resized every time), and that we didn't need any real data from `firstMeasurement` later on.

On another note, yay to Sentry for catching this (FYI @paulbovbel).