### PR TITLE
[RST-4769] Lookup the correct timestamp for the odom->baslink transform

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1945,39 +1945,43 @@ namespace RobotLocalization
             tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
 
             tf2::Transform baseLinkOdomTrans;
-            tf2::fromMsg(
-              tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, filteredPosition.header.stamp, tfTimeout_)
-                .transform,
-              baseLinkOdomTrans);
+            if (RosFilterUtilities::lookupTransformSafe(
+                  tfBuffer_,
+                  baseLinkFrameId_,
+                  odomFrameId_,
+                  filteredPosition.header.stamp,
+                  tfTimeout_,
+                  baseLinkOdomTrans))
+            {
+              /*
+               * First, see these two references:
+               * http://wiki.ros.org/tf/Overview/Using%20Published%20Transforms#lookupTransform
+               * http://wiki.ros.org/geometry/CoordinateFrameConventions#Transform_Direction
+               * We have a transform from mapFrameId_->baseLinkFrameId_, but it would actually transform
+               * a given pose from baseLinkFrameId_->mapFrameId_. We then used lookupTransform, whose
+               * first two arguments are target frame and source frame, to get a transform from
+               * baseLinkFrameId_->odomFrameId_. However, this transform would actually transform data
+               * from odomFrameId_->baseLinkFrameId_. Now imagine that we have a position in the
+               * mapFrameId_ frame. First, we multiply it by the inverse of the
+               * mapFrameId_->baseLinkFrameId, which will transform that data from mapFrameId_ to
+               * baseLinkFrameId_. Now we want to go from baseLinkFrameId_->odomFrameId_, but the
+               * transform we have takes data from odomFrameId_->baseLinkFrameId_, so we need its
+               * inverse as well. We have now transformed our data from mapFrameId_ to odomFrameId_.
+               * However, if we want other users to be able to do the same, we need to broadcast
+               * the inverse of that entire transform.
+              */
 
-            /*
-             * First, see these two references:
-             * http://wiki.ros.org/tf/Overview/Using%20Published%20Transforms#lookupTransform
-             * http://wiki.ros.org/geometry/CoordinateFrameConventions#Transform_Direction
-             * We have a transform from mapFrameId_->baseLinkFrameId_, but it would actually transform
-             * a given pose from baseLinkFrameId_->mapFrameId_. We then used lookupTransform, whose
-             * first two arguments are target frame and source frame, to get a transform from
-             * baseLinkFrameId_->odomFrameId_. However, this transform would actually transform data
-             * from odomFrameId_->baseLinkFrameId_. Now imagine that we have a position in the
-             * mapFrameId_ frame. First, we multiply it by the inverse of the
-             * mapFrameId_->baseLinkFrameId, which will transform that data from mapFrameId_ to
-             * baseLinkFrameId_. Now we want to go from baseLinkFrameId_->odomFrameId_, but the
-             * transform we have takes data from odomFrameId_->baseLinkFrameId_, so we need its
-             * inverse as well. We have now transformed our data from mapFrameId_ to odomFrameId_.
-             * However, if we want other users to be able to do the same, we need to broadcast
-             * the inverse of that entire transform.
-            */
+              tf2::Transform mapOdomTrans;
+              mapOdomTrans.mult(worldBaseLinkTrans, baseLinkOdomTrans);
 
-            tf2::Transform mapOdomTrans;
-            mapOdomTrans.mult(worldBaseLinkTrans, baseLinkOdomTrans);
+              geometry_msgs::TransformStamped mapOdomTransMsg;
+              mapOdomTransMsg.transform = tf2::toMsg(mapOdomTrans);
+              mapOdomTransMsg.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
+              mapOdomTransMsg.header.frame_id = mapFrameId_;
+              mapOdomTransMsg.child_frame_id = odomFrameId_;
 
-            geometry_msgs::TransformStamped mapOdomTransMsg;
-            mapOdomTransMsg.transform = tf2::toMsg(mapOdomTrans);
-            mapOdomTransMsg.header.stamp = filteredPosition.header.stamp + tfTimeOffset_;
-            mapOdomTransMsg.header.frame_id = mapFrameId_;
-            mapOdomTransMsg.child_frame_id = odomFrameId_;
-
-            worldTransformBroadcaster_.sendTransform(mapOdomTransMsg);
+              worldTransformBroadcaster_.sendTransform(mapOdomTransMsg);
+            }
           }
           catch(...)
           {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1945,8 +1945,10 @@ namespace RobotLocalization
             tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
 
             tf2::Transform baseLinkOdomTrans;
-            tf2::fromMsg(tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, ros::Time(0)).transform,
-                         baseLinkOdomTrans);
+            tf2::fromMsg(
+              tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, filteredPosition.header.stamp, tfTimeout_)
+                .transform,
+              baseLinkOdomTrans);
 
             /*
              * First, see these two references:


### PR DESCRIPTION
If r_l is configured to use the map frame, it will publish the map->odom transform to tf. However, what is tracks internally is the map->base_link pose. In order to publish the desired transform, it first looks up the odom->base_link transform from tf. However, instead of looking up the odom->base_link transform at the timestamp of the map->base_link pose, it requests the latest odom->base_link transform. This can lead to inconsistency if the robot traveled significantly between the two timestamps in use.

This PR changes the odom->base_link transform lookup to use the map->base_link timestamp. If the `transform_timeout` parameter is non-zero, the tf lookup will wait that long if the transform is not immediately available. If that lookup fails even after the tf timeout has elapsed, then the behavior reverts to the current system of looking up the most recent available transform.